### PR TITLE
Intro text change & other thoughts

### DIFF
--- a/docs/basics/what-is-site-column.md
+++ b/docs/basics/what-is-site-column.md
@@ -2,7 +2,11 @@
 
 ## Basic Idea
 
-A Site Column is a way to instantiate a single data field for effective reuse.
+A Site Column is a template of a configured column.  By creating a Site Column, you can reuse it anywhere else in the site and not have to manually rebuild its configuration at each reuse.  
+
+When creating a new column you have a choice to either "Create column" or "Add from existing site columns".  Selecting the latter will add a replica of the Site Columm to the location you are working.  Once added, you can edit it in any manner, including changing the name.  
+
+You can return to a site column's configuration at any time and make changes.  Once a column has been created it does not retain any connection to the master site column it was created from.  Changes made to the "Template" do not apply to columns that are based on it.
 
 ## Real World Example
 


### PR DESCRIPTION
I've targeted the language in the intro paragraph to be more for general users and citizen developers.  I had to look up "instantiate" in the dictionary, so I'm guessing many of our target audiences will too.  I also added more detail to the Basic Idea section, just because that's how I roll.

@sympmarc --What do you think about breaking out a separate page for **Universal Site Columns** and **Universal Content Types,** and then referring to that page rather than getting into the details on the Site Col & Content Type pages individually?  I think it would make it easier to describe them.
 
i.e.,  Universal Site Columns and Universal Content Types are created in a special hidden site called the "Content Type Hub" (*tenant*/sites/ContentTypeHub).  Creating a site column or Content type here can propagate it to all sites in your SharePoint environment.  
Sites must subscribe to the Content Type Hub in order for Universal Site Columns and Universal Content Types to be available to them.
Site Columns must be included in a propagated Universal Content Type for it to be included in the propagation--independent Site Columns that are not included in a propagated Universal Content Type are not delivered to other sites.
Changes made to a Universal Site Column or Universal Content Type can be pushed out to all sites that subscribe to it.  This push will update the replica that is available on the subscribed site, it will not change any existing columns or content types that are based upon it.

I think a link to my Metadata Ecosystem Infographic may help here, or using it as a visual...
https://straightenthemaze.com/intranets/technical-intranet/metadata/sharepoint-metadata-infographic/

I'd be happy to tackle the Universal SC/CT page

Cheers!  B